### PR TITLE
#32 simple cov for test coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,5 +100,6 @@ group :test do
   gem 'faker', '~> 3.1'
 end
 
-# Code coverage analysis tool
+
+# Code coverage analysis tool for ruby
 gem 'simplecov', require: false, group: :test

--- a/Gemfile
+++ b/Gemfile
@@ -99,3 +99,6 @@ group :test do
   gem "webdrivers"
   gem 'faker', '~> 3.1'
 end
+
+# Code coverage analysis tool
+gem 'simplecov', require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
       responders
       warden (~> 1.2.3)
     digest (3.1.0)
+    docile (1.4.0)
     erubi (1.10.0)
     et-orbi (1.2.7)
       tzinfo
@@ -262,6 +263,12 @@ GEM
     simple_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -328,6 +335,7 @@ DEPENDENCIES
   selenium-webdriver
   sendgrid-actionmailer (~> 3.2)
   simple_form (~> 5.1)
+  simplecov
   sprockets-rails
   stimulus-rails
   turbo-rails
@@ -339,4 +347,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.3.1
+   2.4.7

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# simple coverage test tool
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
# Description
Adds SimpleCov, an average analysis tool. It gathers code coverage data from [Ruby's built-in Coverage library](https://ruby-doc.org/stdlib/libdoc/coverage/rdoc/Coverage.html). Still, it makes processing its results much easier by providing a clean API to filter, group, merge, format, and display those results, giving you a complete code coverage suite.

## fixes issue [#32]

## Preview
![Screenshot from 2023-03-13 11-13-55](https://user-images.githubusercontent.com/108331299/224651771-7665b885-4b5a-4e41-9578-cb637a9a45ec.png)
