### PR TITLE
docs: Update README with Ruby 3.4.1, Rails 7.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Africa Ruby Community (ARC) Platform
 
 [![Arc Platform CI Workflow](https://github.com/nairuby/arc_platform/actions/workflows/ci.yml/badge.svg)](https://github.com/nairuby/arc_platform/actions/workflows/ci.yml)
+![Ruby](https://img.shields.io/badge/Ruby-3.4.1-red?logo=ruby)
+![Rails](https://img.shields.io/badge/Rails-7.2.2-blue?logo=rubyonrails)
 
 ## Introduction
 The Africa Ruby Community (ARC) Platform is a project aimed at creating a hub for Ruby language enthusiasts in Africa. This platform facilitates connection, knowledge sharing, collaboration on projects, and staying updated with the latest Ruby community developments. Whether you're a seasoned developer or a beginner, this platform offers tailored resources for different countries and cities, merchandise, meetup information, and details about online workshops and webinars.
@@ -61,10 +63,10 @@ asdf plugin add nodejs
 Install Ruby and set the default version by running the following commands:
 
 ```sh
-asdf install ruby 3.2.2 
+asdf install ruby 3.4.1 
 
 # Set the default Ruby version
-asdf global ruby 3.2.2 
+asdf global ruby 3.4.1 
 
 # Update to the latest Rubygems version
 gem update --system
@@ -82,7 +84,7 @@ Confirm the default Ruby version matches the version you just installed.
 which ruby
 #=> /Users/username/.asdf/shims/ruby
 ruby -v
-#=> 3.2.2
+#=> 3.4.1
 ```
 
 Install Node.js for handling Javascript in our Rails app
@@ -103,7 +105,7 @@ npm install -g yarn
 To switch to a different Ruby and Node version for a specific project, you can use the following command to set the Ruby or Node version for that project. You should be in the project directory.
 
 ```sh
-asdf local ruby <ruby version>  # eg 3.0.2
+asdf local ruby <ruby version>  # eg 3.4.1
 asdf local nodejs <nodejs version> # eg 20.9.0
 ```
 


### PR DESCRIPTION
- Updated Ruby version to 3.4.1 in README
- Included Rails 7.2.2 badge
- Improved documentation for dependencies and CI status